### PR TITLE
text/09 -> reset 페이지 라우팅 수정

### DIFF
--- a/docs/text/09/index.html
+++ b/docs/text/09/index.html
@@ -96,17 +96,17 @@
   </li>
   <li>리셋
     <ul>
-      <li><a href="resert#1">복귀 시점</a></li>
-      <li><a href="resert#2">reset 명령어</a></li>
-      <li><a href="resert#3">soft 옵션</a></li>
-      <li><a href="resert#4">mixed 옵션</a></li>
-      <li><a href="resert#5">hard 옵션</a></li>
-      <li><a href="resert#6">소스트리</a></li>
-      <li><a href="resert#7">커밋 합치기</a></li>
-      <li><a href="resert#8">스테이지 리셋</a></li>
-      <li><a href="resert#9">작업 취소</a></li>
-      <li><a href="resert#10">병합 취소</a></li>
-      <li><a href="resert#11">주의할 점</a></li>
+      <li><a href="reset#1">복귀 시점</a></li>
+      <li><a href="reset#2">reset 명령어</a></li>
+      <li><a href="reset#3">soft 옵션</a></li>
+      <li><a href="reset#4">mixed 옵션</a></li>
+      <li><a href="reset#5">hard 옵션</a></li>
+      <li><a href="reset#6">소스트리</a></li>
+      <li><a href="reset#7">커밋 합치기</a></li>
+      <li><a href="reset#8">스테이지 리셋</a></li>
+      <li><a href="reset#9">작업 취소</a></li>
+      <li><a href="reset#10">병합 취소</a></li>
+      <li><a href="reset#11">주의할 점</a></li>
     </ul>
   </li>
   <li>리버트


### PR DESCRIPTION
안녕하세요 이호진 교수님. 저서 Git 교과서 잘 읽었습니다. 많은 공부가 되었습니다.

다른게 아니라 책과 함께 학습 사이트를 통하여 공부를 하던 중, 사이트의 reset 관련 페이지의 링크가 오타로 인하여 404 페이지로 넘어가는 문제를 발견하였습니다. 이에 코드를 수정하여 PR 넣습니다.

확인 부탁드리겠습니다. 감사합니다.